### PR TITLE
[Tasks] Archive rollover via ILM

### DIFF
--- a/app/cmd/setup.go
+++ b/app/cmd/setup.go
@@ -18,7 +18,6 @@ var setupCmd = &cobra.Command{
 	Long:  "Runs various setup routines for Tasques. Includes Index Templates, and Kibana saved objects (if configured)",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		log.Info().Msg("Setting ILM")
 
 		esClient, err := common.NewClient(appConfig.Elasticsearch)
 		if err != nil {

--- a/config/tasques.example.yaml
+++ b/config/tasques.example.yaml
@@ -96,3 +96,13 @@ tasques:
         scroll_size: 500
         # How long the scroll should last
         scroll_ttl: 1m
+    # ILM-setup related settings
+    life_cycle_setup:
+      # ILM setup for achived Tasks
+      archived_tasks:
+        # Whether or not to use ILM for archived Tasks data
+        enabled: true
+        # Optional custom policy
+        # custom_policy:
+        #  name: custom_name
+        #  policy: some Yaml...

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -20,6 +20,7 @@ type App struct {
 	Logging         *Logging            `json:"logging,omitempty" mapstructure:"logging"`
 	Tasks           Tasks               `json:"tasks" mapstructure:"tasks"`
 	Recurring       Recurring           `json:"recurring" mapstructure:"recurring"`
+	LifeCycleSetup  LifeCycleSetup      `json:"life_cycle_setup" mapstructure:"life_cycle_setup"`
 }
 
 type Logging struct {
@@ -97,4 +98,18 @@ type Recurring struct {
 type LeaderLock struct {
 	CheckInterval      time.Duration `json:"check_interval" mapstructure:"check_interval"`
 	ReportLagTolerance time.Duration `json:"report_lag_tolerance" mapstructure:"report_lag_tolerance"`
+}
+
+type LifeCycleSetup struct {
+	ArchivedTasks LifeCycleSettings `json:"archived_tasks" mapstructure:"archived_tasks"`
+}
+
+type LifeCycleSettings struct {
+	Enabled      bool                   `json:"enabled" mapstructure:"enabled"`
+	CustomPolicy *CustomLifeCyclePolicy `json:"custom_policy,omitempty" mapstructure:"custom_policy"`
+}
+
+type CustomLifeCyclePolicy struct {
+	Name   string                 `json:"name" mapstructure:"name"`
+	Policy map[string]interface{} `json:"policy" mapstructure:"policy"`
 }

--- a/internal/infra/elasticsearch/index/lifecycle_management.go
+++ b/internal/infra/elasticsearch/index/lifecycle_management.go
@@ -1,0 +1,207 @@
+package index
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/rs/zerolog/log"
+
+	"github.com/lloydmeta/tasques/internal/config"
+	"github.com/lloydmeta/tasques/internal/infra/elasticsearch/common"
+	"github.com/lloydmeta/tasques/internal/infra/elasticsearch/task"
+)
+
+var (
+	DefaultArchivedTasquesPolicyName = "tasques_archived_tasks_policy"
+	DefaulttArchivedTasquesPolicy    = Json{
+		"phases": Json{
+			"hot": Json{
+				"actions": Json{
+					"rollover": Json{
+						"max_size": "50GB",
+						"max_age":  "1d",
+					},
+				},
+			},
+			"warm": Json{
+				"min_age": "7d",
+				"actions": Json{
+					"readonly": Json{},
+				},
+			},
+			"cold": Json{
+				"min_age": "30d",
+				"actions": Json{
+					"freeze": Json{},
+				},
+			},
+		},
+	}
+)
+
+type ILMSetup interface {
+
+	// A Check to make sure that, if enabled, the setup was previously carried out
+	// Does NOT make sure the existing setup, if present, is up to date !
+	Check(ctx context.Context) error
+
+	// Returns a function for modifying the Index Template for Archived Tasks
+	ArchivedTemplateHook() func(t *Template)
+
+	// Performs ILM setup, if required
+	InstallPolicies(ctx context.Context) error
+
+	// Bootstraps the indices that were set up for ILM
+	BootstrapIndices(ctx context.Context) error
+}
+
+type impl struct {
+	esClient *elasticsearch.Client
+	config   config.LifeCycleSetup
+}
+
+func NewILMSetup(esClient *elasticsearch.Client, config config.LifeCycleSetup) ILMSetup {
+	return &impl{
+		esClient: esClient,
+		config:   config,
+	}
+}
+
+func (i *impl) ArchivedTemplateHook() func(t *Template) {
+	return func(t *Template) {
+		if i.config.ArchivedTasks.Enabled {
+			policyName := i.archivedTasksPolicyName()
+			t.Patterns = []Pattern{fmt.Sprintf("%s-*", task.TasquesArchiveIndex)}
+			if t.Settings == nil {
+				t.Settings = make(Json)
+			}
+			t.Settings["index.lifecycle.name"] = policyName
+			t.Settings["index.lifecycle.rollover_alias"] = task.TasquesArchiveIndex
+		}
+	}
+}
+
+func (i *impl) InstallPolicies(ctx context.Context) error {
+	if i.config.ArchivedTasks.Enabled {
+		policyName := i.archivedTasksPolicyName()
+		asBytes, err := json.Marshal(i.archivedTasksPolicy())
+		if err != nil {
+			return common.JsonSerdesErr{Underlying: []error{err}}
+		}
+		log.Info().RawJSON("body", asBytes).Str("policy_name", string(policyName)).Msg("Applying lifecycle policy")
+		req := esapi.ILMPutLifecycleRequest{
+			Policy: policyName,
+			Body:   bytes.NewReader(asBytes),
+		}
+		rawResp, err := req.Do(ctx, i.esClient)
+		if err != nil {
+			return common.ElasticsearchErr{Underlying: err}
+		}
+		defer rawResp.Body.Close()
+
+		switch rawResp.StatusCode {
+		case 200:
+			return nil
+		default:
+			return common.UnexpectedEsStatusError(rawResp)
+		}
+
+	} else {
+		return nil
+	}
+}
+
+func (i *impl) Check(ctx context.Context) error {
+	if i.config.ArchivedTasks.Enabled {
+		policyName := i.archivedTasksPolicyName()
+		req := esapi.ILMGetLifecycleRequest{
+			Policy: policyName,
+		}
+		rawResp, err := req.Do(ctx, i.esClient)
+		if err != nil {
+			return common.ElasticsearchErr{Underlying: err}
+		}
+		defer rawResp.Body.Close()
+
+		switch rawResp.StatusCode {
+		case 200:
+			return nil
+		case 404:
+			return PolicyNotInstalled{NotInstalled: []string{policyName}}
+		default:
+			return common.UnexpectedEsStatusError(rawResp)
+		}
+
+	} else {
+		return nil
+	}
+}
+
+func (i *impl) archivedTasksPolicyName() string {
+	if i.config.ArchivedTasks.CustomPolicy != nil {
+		return i.config.ArchivedTasks.CustomPolicy.Name
+	} else {
+		return DefaultArchivedTasquesPolicyName
+	}
+}
+func (i *impl) archivedTasksPolicy() Json {
+	if i.config.ArchivedTasks.CustomPolicy != nil {
+		return Json{
+			"policy": i.config.ArchivedTasks.CustomPolicy.Policy,
+		}
+	} else {
+		return Json{
+			"policy": DefaulttArchivedTasquesPolicy,
+		}
+	}
+}
+
+func (i *impl) BootstrapIndices(ctx context.Context) error {
+	if i.config.ArchivedTasks.Enabled {
+		indexCreateBody := buildWriteAlias(task.TasquesArchiveIndex)
+		indexCreateBodyAsBytes, err := json.Marshal(indexCreateBody)
+		if err != nil {
+			return common.JsonSerdesErr{Underlying: []error{err}}
+		}
+		req := esapi.IndicesCreateRequest{
+			Index: fmt.Sprintf("%%3C%s-%%7Bnow%%2Fd%%7D-000001%%3E", task.TasquesArchiveIndex),
+			Body:  bytes.NewReader(indexCreateBodyAsBytes),
+		}
+		rawResp, err := req.Do(ctx, i.esClient)
+		if err != nil {
+			return common.ElasticsearchErr{Underlying: err}
+		}
+		defer rawResp.Body.Close()
+		respStatus := rawResp.StatusCode
+		switch {
+		case 200 <= respStatus || respStatus <= 299:
+			return nil
+		default:
+			return common.UnexpectedEsStatusError(rawResp)
+		}
+	} else {
+		return nil
+	}
+}
+
+type PolicyNotInstalled struct {
+	NotInstalled []string
+}
+
+func (t PolicyNotInstalled) Error() string {
+	return fmt.Sprintf("One or more app ILM policies were not installed. Please run the setup command to install them [%v]", t.NotInstalled)
+}
+
+func buildWriteAlias(alias string) Json {
+	return Json{
+		"aliases": Json{
+			alias: Json{
+				"is_write_index": true,
+			},
+		},
+	}
+}

--- a/internal/infra/elasticsearch/integration_tests/archived_tasks.go
+++ b/internal/infra/elasticsearch/integration_tests/archived_tasks.go
@@ -1,0 +1,7 @@
+// +build integration
+
+package integration_tests
+
+import "sync"
+
+var ArchivedTasksLock = sync.Mutex{}

--- a/internal/infra/elasticsearch/integration_tests/ilm_setup_test.go
+++ b/internal/infra/elasticsearch/integration_tests/ilm_setup_test.go
@@ -1,0 +1,56 @@
+// +build integration
+
+package integration_tests
+
+import (
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lloydmeta/tasques/internal/infra/elasticsearch/index"
+	"github.com/lloydmeta/tasques/internal/infra/elasticsearch/task"
+)
+
+func Test_IlmSetup(t *testing.T) {
+	ArchivedTasksLock.Lock()
+	defer ArchivedTasksLock.Unlock()
+
+	if err := deleteArchivedTasksIndex(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	setup := index.NewILMSetup(esClient, lifecycleSetupSettings)
+
+	var NotInstalled index.PolicyNotInstalled
+	err := setup.Check(ctx)
+	assert.IsType(t, NotInstalled, err)
+
+	assert.NotNil(t, setup.ArchivedTemplateHook())
+
+	err = setup.InstallPolicies(ctx)
+	assert.NoError(t, err)
+
+	err = setup.BootstrapIndices(ctx)
+	assert.NoError(t, err)
+
+	err = setup.Check(ctx)
+	assert.NoError(t, err)
+}
+
+func deleteArchivedTasksIndex() error {
+	req := esapi.IndicesDeleteRequest{
+		Index:             []string{task.TasquesArchiveIndex},
+		AllowNoIndices:    esapi.BoolPtr(true),
+		IgnoreUnavailable: esapi.BoolPtr(true),
+	}
+	rawResp, err := req.Do(ctx, esClient)
+	defer rawResp.Body.Close()
+	if err != nil {
+		return err
+	} else {
+		return nil
+	}
+
+}

--- a/internal/infra/elasticsearch/integration_tests/task_service_test.go
+++ b/internal/infra/elasticsearch/integration_tests/task_service_test.go
@@ -1156,6 +1156,8 @@ func Test_esTaskService_FailTimedOutTasks(t *testing.T) {
 }
 
 func Test_esTaskService_ArchiveOldTasks(t *testing.T) {
+	ArchivedTasksLock.Lock()
+	defer ArchivedTasksLock.Unlock()
 	service := buildTasksService()
 
 	queueToSeed := queue.Name("claimed-tasks-to-expire")

--- a/internal/infra/elasticsearch/integration_tests/template_test.go
+++ b/internal/infra/elasticsearch/integration_tests/template_test.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/lloydmeta/tasques/internal/config"
 	"github.com/lloydmeta/tasques/internal/infra/elasticsearch/index"
 )
 
 func Test_DefaultTemplatesSetup_Run(t *testing.T) {
-	subject := index.DefaultTemplateSetup(esClient)
+	ilmSetup := index.NewILMSetup(esClient, lifecycleSetupSettings)
+	subject := index.DefaultTemplateSetup(esClient, ilmSetup.ArchivedTemplateHook())
 
 	err := subject.Run(context.Background())
 	assert.NoError(t, err)
@@ -20,4 +22,10 @@ func Test_DefaultTemplatesSetup_Run(t *testing.T) {
 	err = subject.Check(context.Background())
 	assert.NoError(t, err)
 
+}
+
+var lifecycleSetupSettings = config.LifeCycleSetup{
+	ArchivedTasks: config.LifeCycleSettings{
+		Enabled: true,
+	},
 }

--- a/internal/infra/server/components.go
+++ b/internal/infra/server/components.go
@@ -64,8 +64,12 @@ func NewComponents(config *config.App) (*Components, error) {
 		return nil, err
 	} else {
 
-		indexTemplateChecker := index.DefaultTemplateSetup(esClient)
+		ilmSetup := index.NewILMSetup(esClient, config.LifeCycleSetup)
+		indexTemplateChecker := index.DefaultTemplateSetup(esClient, ilmSetup.ArchivedTemplateHook())
 		if err = indexTemplateChecker.Check(context.Background()); err != nil {
+			return nil, err
+		}
+		if err = ilmSetup.Check(context.Background()); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Add the ability to set up lifecycle management of the archived
Tasks index, including allowing customising the policy.

Other changes
- Config update
- Add check for ILM setup when running the main app
