### PR TITLE
[Cleanup] Add server.Setup for abstracting server bootstrapping

### DIFF
--- a/app/cmd/setup.go
+++ b/app/cmd/setup.go
@@ -8,50 +8,25 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lloydmeta/tasques/internal/infra/elasticsearch/common"
-	"github.com/lloydmeta/tasques/internal/infra/elasticsearch/index"
-	"github.com/lloydmeta/tasques/internal/infra/kibana/saved_objects"
+	"github.com/lloydmeta/tasques/internal/infra/server"
 )
 
 var setupCmd = &cobra.Command{
 	Use:   "setup",
 	Short: "Run tasques setup",
-	Long:  "Runs various setup routines for Tasques. Includes Index Templates, and Kibana saved objects (if configured)",
+	Long:  "Runs various setup routines for Tasques. Includes Index Templates, Kibana saved objects, and ILM setup (if configured)",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-
+		httpClient := http.Client{}
 		esClient, err := common.NewClient(appConfig.Elasticsearch)
 		if err != nil {
 			log.Fatal().Err(err).Msg("Could not setup Elasticsearch client")
 		}
-		log.Info().Msg("Setting up ILM")
-		ilmSetup := index.NewILMSetup(esClient, appConfig.LifecycleSetup)
-		if err := ilmSetup.InstallPolicies(ctx); err != nil {
-			log.Fatal().Err(err).Msg("Could not install ILM policies")
-		}
 
-		// This needs to happen after ILM because templates refer to ILM policies
-		log.Info().Msg("Setting up Index templates")
-		templatesSetup := index.DefaultTemplateSetup(esClient, ilmSetup.ArchivedTemplateHook())
-		if err != nil {
-			log.Fatal().Err(err).Msg("Could not setup Template Setter Upper")
+		setup := server.NewSetup(&httpClient, esClient, &appConfig)
+		if err := setup.RunIfNeeded(ctx); err != nil {
+			log.Fatal().Err(err).Msg("Setup failed")
 		}
-		if err := templatesSetup.Run(ctx); err != nil {
-			log.Fatal().Err(err).Msg("Failed to install index templates")
-		}
-
-		if err := ilmSetup.BootstrapIndices(ctx); err != nil {
-			log.Fatal().Err(err).Msg("Could not bootstrap indices for ILM")
-		}
-
-		if appConfig.KibanaClient != nil {
-			log.Info().Msg("Setting up Kibana saved objects")
-			httpClient := http.Client{}
-			importer := saved_objects.NewImporter(*appConfig.KibanaClient, &httpClient)
-			if err := importer.Run(ctx); err != nil {
-				log.Fatal().Err(err).Msg("Failed to install Kibana saved objects")
-			}
-		}
-		log.Info().Msg("Setup complete.")
 	},
 }
 

--- a/internal/infra/elasticsearch/index/lifecycle_management.go
+++ b/internal/infra/elasticsearch/index/lifecycle_management.go
@@ -59,19 +59,19 @@ type ILMSetup interface {
 	BootstrapIndices(ctx context.Context) error
 }
 
-type impl struct {
+type ilmSetupImpl struct {
 	esClient *elasticsearch.Client
 	config   config.LifecycleSetup
 }
 
 func NewILMSetup(esClient *elasticsearch.Client, config config.LifecycleSetup) ILMSetup {
-	return &impl{
+	return &ilmSetupImpl{
 		esClient: esClient,
 		config:   config,
 	}
 }
 
-func (i *impl) ArchivedTemplateHook() func(t *Template) {
+func (i *ilmSetupImpl) ArchivedTemplateHook() func(t *Template) {
 	return func(t *Template) {
 		if i.config.ArchivedTasks.Enabled {
 			policyName := i.archivedTasksPolicyName()
@@ -85,7 +85,7 @@ func (i *impl) ArchivedTemplateHook() func(t *Template) {
 	}
 }
 
-func (i *impl) InstallPolicies(ctx context.Context) error {
+func (i *ilmSetupImpl) InstallPolicies(ctx context.Context) error {
 	if i.config.ArchivedTasks.Enabled {
 		policyName := i.archivedTasksPolicyName()
 		asBytes, err := json.Marshal(i.archivedTasksPolicy())
@@ -115,7 +115,7 @@ func (i *impl) InstallPolicies(ctx context.Context) error {
 	}
 }
 
-func (i *impl) Check(ctx context.Context) error {
+func (i *ilmSetupImpl) Check(ctx context.Context) error {
 	if i.config.ArchivedTasks.Enabled {
 		policyName := i.archivedTasksPolicyName()
 		req := esapi.ILMGetLifecycleRequest{
@@ -141,14 +141,14 @@ func (i *impl) Check(ctx context.Context) error {
 	}
 }
 
-func (i *impl) archivedTasksPolicyName() string {
+func (i *ilmSetupImpl) archivedTasksPolicyName() string {
 	if i.config.ArchivedTasks.CustomPolicy != nil {
 		return i.config.ArchivedTasks.CustomPolicy.Name
 	} else {
 		return DefaultArchivedTasquesPolicyName
 	}
 }
-func (i *impl) archivedTasksPolicy() Json {
+func (i *ilmSetupImpl) archivedTasksPolicy() Json {
 	if i.config.ArchivedTasks.CustomPolicy != nil {
 		return Json{
 			"policy": i.config.ArchivedTasks.CustomPolicy.Policy,
@@ -160,7 +160,7 @@ func (i *impl) archivedTasksPolicy() Json {
 	}
 }
 
-func (i *impl) BootstrapIndices(ctx context.Context) error {
+func (i *ilmSetupImpl) BootstrapIndices(ctx context.Context) error {
 	if i.config.ArchivedTasks.Enabled {
 		indexCreateBody := buildWriteAlias(task.TasquesArchiveIndex)
 		indexCreateBodyAsBytes, err := json.Marshal(indexCreateBody)

--- a/internal/infra/elasticsearch/integration_tests/server_setup_test.go
+++ b/internal/infra/elasticsearch/integration_tests/server_setup_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/lloydmeta/tasques/internal/infra/server"
 )
 
-func Test_Setup(t *testing.T) {
+func Test_Server_Setup(t *testing.T) {
 
 	ArchivedTasksLock.Lock()
 	defer ArchivedTasksLock.Unlock()

--- a/internal/infra/elasticsearch/integration_tests/setup_test.go
+++ b/internal/infra/elasticsearch/integration_tests/setup_test.go
@@ -1,0 +1,74 @@
+// +build integration
+
+package integration_tests
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lloydmeta/tasques/internal/config"
+	"github.com/lloydmeta/tasques/internal/infra/server"
+)
+
+func Test_Setup(t *testing.T) {
+
+	ArchivedTasksLock.Lock()
+	defer ArchivedTasksLock.Unlock()
+
+	if err := deleteArchivedTasksIndex(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.EqualValues(t, req.URL.String(), "http://localhost_dummy/api/saved_objects/_import?overwrite=true")
+		return &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(`{"success": true}`)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+	setup := server.NewSetup(client, esClient, &dummyAppConfig)
+
+	err := setup.Check(ctx)
+	assert.Error(t, err)
+
+	err = setup.RunIfNeeded(ctx)
+	assert.NoError(t, err)
+
+	err = setup.Check(ctx)
+	assert.NoError(t, err)
+
+}
+
+var dummyAppConfig = config.App{
+	KibanaClient: &config.KibanaClient{
+		Address: "http://localhost_dummy",
+	},
+	LifecycleSetup: config.LifecycleSetup{
+		ArchivedTasks: config.LifecycleSettings{
+			Enabled: true,
+		},
+	},
+}
+
+// RoundTripFunc .
+type RoundTripFunc func(req *http.Request) *http.Response
+
+// RoundTrip .
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+//NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: fn,
+	}
+}

--- a/internal/infra/kibana/saved_objects/importer.go
+++ b/internal/infra/kibana/saved_objects/importer.go
@@ -39,22 +39,27 @@ var ndjson = `{"attributes":{"buildNum":27675,"defaultIndex":".tasques_queue-*"}
 {"attributes":{"description":"","kibanaSavedObjectMeta":{"searchSourceJSON":"{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"filter\":[]}"},"title":"Tasques State vs CreatedAt","uiStateJSON":"{}","version":1,"visState":"{\"title\":\"Tasques State vs CreatedAt\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"filter\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":true,\"type\":\"histogram\",\"mode\":\"stacked\",\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"lineWidth\":2,\"showCircles\":true,\"data\":{\"label\":\"Count\",\"id\":\"1\"}}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false,\"labels\":{\"show\":false},\"thresholdLine\":{\"show\":false,\"value\":10,\"width\":1,\"style\":\"full\",\"color\":\"#34130C\"},\"dimensions\":{\"x\":{\"accessor\":0,\"format\":{\"id\":\"date\",\"params\":{\"pattern\":\"HH:mm:ss\"}},\"params\":{\"date\":true,\"interval\":\"PT30S\",\"intervalESValue\":30,\"intervalESUnit\":\"s\",\"format\":\"HH:mm:ss\",\"bounds\":{\"min\":\"2020-02-09T05:48:54.769Z\",\"max\":\"2020-02-09T06:03:54.769Z\"}},\"aggType\":\"date_histogram\"},\"y\":[{\"accessor\":3,\"format\":{\"id\":\"number\"},\"params\":{},\"aggType\":\"count\"}],\"series\":[{\"accessor\":1,\"format\":{\"id\":\"string\"},\"params\":{},\"aggType\":\"significant_terms\"},{\"accessor\":2,\"format\":{\"id\":\"string\"},\"params\":{},\"aggType\":\"significant_terms\"}]}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"metadata.created_at\",\"timeRange\":{\"from\":\"now-15m\",\"to\":\"now\"},\"useNormalizedEsInterval\":true,\"scaleMetricValues\":false,\"interval\":\"auto\",\"drop_partials\":false,\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"5\",\"enabled\":true,\"type\":\"significant_terms\",\"schema\":\"group\",\"params\":{\"field\":\"state\",\"size\":10}}]}"},"id":"0de746e0-4b02-11ea-99ce-a1882afeef23","migrationVersion":{"visualization":"7.4.2"},"references":[{"id":".tasques_queue-*","name":"kibanaSavedObjectMeta.searchSourceJSON.index","type":"index-pattern"}],"type":"visualization","updated_at":"2020-03-05T08:04:59.514Z","version":"WzI0LDFd"}
 {"exportedCount":23,"missingRefCount":0,"missingReferences":[]}`
 
+type Importer interface {
+	// Run kicks off the importing
+	Run(ctx context.Context) error
+}
+
 // Importer, when run imports Tasques-specific Kibana Saved Objects
-type Importer struct {
+type impl struct {
 	conf       config.KibanaClient
 	httpClient *http.Client
 }
 
 // NewImporter returns a new Importer
 func NewImporter(conf config.KibanaClient, httpClient *http.Client) Importer {
-	return Importer{
+	return &impl{
 		conf:       conf,
 		httpClient: httpClient,
 	}
 }
 
 // Run kicks off the importing
-func (i *Importer) Run(ctx context.Context) error {
+func (i *impl) Run(ctx context.Context) error {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	part, err := writer.CreateFormFile("file", "tasques_saved_objects.ndjson")

--- a/internal/infra/server/setup.go
+++ b/internal/infra/server/setup.go
@@ -62,7 +62,6 @@ func (i *impl) RunIfNeeded(ctx context.Context) error {
 		if _, policiesNotFound := err.(index.PolicyNotInstalled); policiesNotFound {
 			needsIlmSetup = true
 		} else {
-			log.Info().Msg("Skipping ILM setup")
 			return err
 		}
 	}
@@ -87,6 +86,8 @@ func (i *impl) RunIfNeeded(ctx context.Context) error {
 				log.Error().Err(err).Msg("Failed to install Kibana saved objects")
 				return err
 			}
+		} else {
+			return err
 		}
 	}
 

--- a/internal/infra/server/setup.go
+++ b/internal/infra/server/setup.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/rs/zerolog/log"
+
+	"github.com/lloydmeta/tasques/internal/config"
+	"github.com/lloydmeta/tasques/internal/infra/elasticsearch/index"
+	"github.com/lloydmeta/tasques/internal/infra/kibana/saved_objects"
+)
+
+// Setup abstracts away:
+//
+// 1. Setting up the environment for running Tasques
+// 2. Checking that things are set up
+type Setup interface {
+
+	// Check returns an error if all the necessary setup is not complete
+	Check(ctx context.Context) error
+
+	// RunIfNeeded attempts to run the subroutines necessary, no more no less
+	RunIfNeeded(ctx context.Context) error
+}
+
+type impl struct {
+	ilm            index.ILMSetup
+	templateSetup  index.TemplateSetup
+	kibanaImporter saved_objects.Importer
+}
+
+// NewSetup returns a Setup implementation
+func NewSetup(httpClient *http.Client, esClient *elasticsearch.Client, config *config.App) Setup {
+
+	ilmSetup := index.NewILMSetup(esClient, config.LifecycleSetup)
+	templateSetup := index.DefaultTemplateSetup(esClient, ilmSetup.ArchivedTemplateHook())
+	kibanaImporter := saved_objects.NewImporter(*config.KibanaClient, httpClient)
+
+	return &impl{
+		ilm:            ilmSetup,
+		templateSetup:  templateSetup,
+		kibanaImporter: kibanaImporter,
+	}
+}
+
+func (i *impl) Check(ctx context.Context) error {
+	if err := i.ilm.Check(ctx); err != nil {
+		return err
+	} else if err := i.templateSetup.Check(ctx); err != nil {
+		return err
+	} else {
+		return nil
+	}
+}
+
+func (i *impl) RunIfNeeded(ctx context.Context) error {
+
+	needsIlmSetup := false
+	if err := i.ilm.Check(ctx); err != nil {
+		if _, policiesNotFound := err.(index.PolicyNotInstalled); policiesNotFound {
+			needsIlmSetup = true
+		} else {
+			log.Info().Msg("Skipping ILM setup")
+			return err
+		}
+	}
+
+	if needsIlmSetup {
+		log.Info().Msg("Setting up ILM")
+		if err := i.ilm.InstallPolicies(ctx); err != nil {
+			log.Error().Err(err).Msg("Could not install ILM policies")
+			return err
+		}
+	}
+
+	if err := i.templateSetup.Check(ctx); err != nil {
+		if _, templateNotFound := err.(index.TemplatesNotInstalled); templateNotFound {
+			log.Info().Msg("Setting up Index templates")
+			if err := i.templateSetup.Run(ctx); err != nil {
+				log.Error().Err(err).Msg("Failed to install index templates")
+				return err
+			}
+			log.Info().Msg("Installing Kibana Saved Objects")
+			if err := i.kibanaImporter.Run(ctx); err != nil {
+				log.Error().Err(err).Msg("Failed to install Kibana saved objects")
+				return err
+			}
+		}
+	}
+
+	if needsIlmSetup {
+		log.Info().Msg("Bootstrapping ILM indices")
+		if err := i.ilm.BootstrapIndices(ctx); err != nil {
+			log.Error().Err(err).Msg("Could not bootstrap indices for ILM")
+			return err
+		}
+	}
+
+	log.Info().Msg("Setup complete")
+	return nil
+}


### PR DESCRIPTION
Introduce server.Setup as an interface that allows us to:

1. Bootstrap the environment
2. Ensure it is bootstrapped

Then use this when:

1. Running the `setup` command
2. Checking that setup has been run from Components#Run()

This also makes it possible to write an integration test for
this previously untested code.

Signed-off-by: lloydmeta <lloydmeta@gmail.com>