### PR TITLE
[Enhancement] Clock-insensitive leader lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,6 @@ of these internal Tasks, as a new Leader will be elected and take over if the cu
 
 Running multiple servers also allows for zero-downtime rollouts of new versions of Tasques server.
 
-**Note:** 
-
-The current implementation of the leader lock depends on reasonable clock sync on running systems. In practice,
-this is not an issue on most systems, container orchestration engines and Cloud providers thanks to NTP sync being used
-by default; a lot of tools and monitoring already depend on clocks being synced! 
-
-That said, the tolerance for drift can be configured using the `tasques.server.recurring.leader_lock.report_lag_tolerance`
-setting (override using `TASQUES_SERVER_RECURRING_LEADER_LOCK_REPORT_LAG_TOLERANCE` env variable) as a duration string
-(e.g. `10s`).
-
 ### Delivery
 
 Assuming there is no data loss at the ES level, Tasques provides at-least-once delivery, ensuring that it only allows a

--- a/config/tasques.example.yaml
+++ b/config/tasques.example.yaml
@@ -61,16 +61,12 @@ tasques:
       # Settings for the leader lock functionalit
       leader_lock:
         # How often the lock loop should run (check and re-enforce leader)
-        check_interval: 1s
+        run_interval: 1s
         # How long to wait before a leader lock claim is considered stale/obsolete (should be longer than check interval)
         #
         # Increasing this setting means a longer wait before leadership is taken over in the event of the leader not
-        # renewing its lock claim (exit or crash), but if the system clocks on your servers drift significantly (e.g. NTP
-        # is off or broken) setting this higher than the max expected drift will decrease flappiness.
-        #
-        # That said, if you have high clock drift between servers, it's highly recommended to fix that first before
-        # adjusting this because you probably have Much Bigger Problems TM
-        report_lag_tolerance: 10s
+        # renewing its lock claim (exit or crash).
+        leader_lock_lease: 10s
       # Settings for the timed out task reaping functionality
       timed_out_tasks_reaper:
         # How long to wait between runs

--- a/config/tasques.example.yaml
+++ b/config/tasques.example.yaml
@@ -66,7 +66,7 @@ tasques:
         #
         # Increasing this setting means a longer wait before leadership is taken over in the event of the leader not
         # renewing its lock claim (exit or crash).
-        leader_lock_lease: 10s
+        leader_lock_lease: 5s
       # Settings for the timed out task reaping functionality
       timed_out_tasks_reaper:
         # How long to wait between runs

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -96,8 +96,8 @@ type Recurring struct {
 }
 
 type LeaderLock struct {
-	CheckInterval      time.Duration `json:"check_interval" mapstructure:"check_interval"`
-	ReportLagTolerance time.Duration `json:"report_lag_tolerance" mapstructure:"report_lag_tolerance"`
+	RunInterval     time.Duration `json:"run_interval" mapstructure:"run_interval"`
+	LeaderLockLease time.Duration `json:"leader_lock_lease" mapstructure:"leader_lock_lease"`
 }
 
 type LifecycleSetup struct {

--- a/internal/infra/server/components.go
+++ b/internal/infra/server/components.go
@@ -167,8 +167,8 @@ func buildRecurringTasksLeaderLock(conf config.LeaderLock, esClient *elasticsear
 	return infraLeader.NewLeaderLock(
 		"recurring-tasks-leader",
 		esClient,
-		conf.CheckInterval,
-		conf.ReportLagTolerance,
+		conf.RunInterval,
+		conf.LeaderLockLease,
 		tracer,
 	)
 }


### PR DESCRIPTION
This updates the leader lock implementation so that it's no longer sensitive to
differences in system clock on Tasques servers.

It does this by making non-Leaders eagerly try to gain leadership after sleeping
for the leader lock period.

Changes:

* In CHECKER mode: stashes the current leader lock document even if
  not leader, then *waits* for the leader lock lease period, and sets
  mode to USURPER
* In USURPER mode: tries to jostle for leadership right away
  * If there is a conflict, then someone else is leader (in normal cases, this is
    likely existing leader); go into CHECKER mode and re-loop.
* When writing the leader lock document, we now also write the leader lock
  lease period, which non-leaders will wait for before trying to USURP.
  This allows config changes for leader_lock_lease to be rolled out
  to servers incrementally without suddenly changing wait time on the original
  leader.

Credit:

https://aws.amazon.com/blogs/database/building-distributed-locks-with-the-dynamodb-lock-client/