### PR TITLE
[Enhancement] Better support for high-frequency Recurring Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,18 @@ When submitting/creating a Task, you can optionally specify an "id" field, which
 the submission will fail.
 
 Note that idempotency is only for un-archived Tasks: it's possible for a Task to be created with the same Id as another 
-already archived Task. The `archive_older_than` period config can be tweaked if this is an issue. 
+already archived Task. The `archive_older_than` period config can be tweaked if this is an issue.
+
+### Recurring Tasks
+
+Tasques comes with support for scheduling Tasks enqueued at a given cron expression (delegating to [robconfig/cron](https://github.com/robfig/cron),
+so check there for supported expressions).
+
+There is also support to skip enqueueing Tasks for a Recurring Task if there are existing outstanding (not dead or done)
+that belong to it. For high-frequency Recurring Tasks (higher than once every ~2 seconds) this is subject to limitations
+in ES itself, since it refreshes Indices on a [configurable interval](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html).
+To address this, you can configure the ES index refresh interval to be more frequent, or you can configure
+tasques itself to be more aggressive about refreshing indices (see `config/tasques.example.yaml` for details).  
 
 ### Dev
 

--- a/config/tasques.example.yaml
+++ b/config/tasques.example.yaml
@@ -52,6 +52,13 @@ tasques:
         # This is mostly an implementation detail around finding outstanding Tasks for scheduling / not scheduling
         # Recurring Tasks that you don't need to worry too much about unless if you are using that feature
         refresh_if_last_touched_over: 30s
+        # If a Queue was last refreshed / touched *under* this threshold, we will refresh anyways.
+        #
+        # This is to set a lower threshold for the Queue index refresh optimisation for Recurring Tasks that
+        # have skip_if_outstanding_tasks_exist set to `true` and have a *very* high frequency. In those cases,
+        # we want to refresh the Index more frequently in order to get an up-to-date count of how many Tasks
+        # are outstanding (by default ES refreshes per-second for indices that were searched within the last 30s)
+        refresh_if_last_touched_under: 2s
       defaults:
         # Default block_for for claims
         block_for: 3s

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -52,6 +52,7 @@ type Tasks struct {
 type Queues struct {
 	LastActivityTrackerMaxSize uint          `json:"last_activity_tracker_max_size" mapstructure:"last_activity_tracker_max_size"`
 	RefreshIfLastTouchedOver   time.Duration `json:"refresh_if_last_touched_over" mapstructure:"refresh_if_last_touched_over"`
+	RefreshIfLastTouchedUnder  time.Duration `json:"refresh_if_last_touched_under" mapstructure:"refresh_if_last_touched_under"`
 }
 
 type TasksDefaults struct {

--- a/internal/infra/cron/task/recurring/scheduler.go
+++ b/internal/infra/cron/task/recurring/scheduler.go
@@ -183,14 +183,19 @@ type zeroLogCronLogger struct {
 func (z zeroLogCronLogger) Info(msg string, keysAndValues ...interface{}) {
 	if log.Info().Enabled() {
 		formatted := formatTimeValues(keysAndValues)
-		log.Info().Fields(formatted).Msg(msg)
+		log.Info().
+			Fields(formatted).
+			Msg(msg)
 	}
 }
 
 func (z zeroLogCronLogger) Error(err error, msg string, keysAndValues ...interface{}) {
 	if log.Error().Enabled() {
 		formatted := formatTimeValues(keysAndValues)
-		log.Error().Err(err).Fields(formatted).Msg(msg)
+		log.Error().
+			Err(err).
+			Fields(formatted).
+			Msg(msg)
 	}
 }
 

--- a/internal/infra/cron/task/recurring/scheduler.go
+++ b/internal/infra/cron/task/recurring/scheduler.go
@@ -1,6 +1,7 @@
 package recurring
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -56,7 +57,7 @@ func (i *schedulerImpl) Schedule(task recurring.Task) error {
 		i.cron.Remove(entryId)
 		delete(i.idsToEntryIds, task.ID)
 	}
-	entryId, err := i.cron.AddFunc(string(task.ScheduleExpression), func() {
+	var cronJob cron.Job = cron.FuncJob(func() {
 		if log.Debug().Enabled() {
 			log.Debug().
 				Str("id", string(task.ID)).
@@ -114,6 +115,17 @@ func (i *schedulerImpl) Schedule(task recurring.Task) error {
 		}
 		tx.End()
 	})
+
+	if task.SkipIfOutstandingTasksExist {
+		cronJob = cron.NewChain(
+			cron.Recover(zeroLogCronLogger{}),
+			cron.DelayIfStillRunning(zeroLogCronLogger{}),
+		).Then(cronJob)
+	} else {
+		cron.NewChain(cron.Recover(zeroLogCronLogger{})).Then(cronJob)
+	}
+
+	entryId, err := i.cron.AddJob(string(task.ScheduleExpression), cronJob)
 	i.idsToEntryIds[task.ID] = entryId
 	return err
 }
@@ -163,4 +175,44 @@ func (i *schedulerImpl) taskDefToNewTask(id task.RecurringTaskId, def *recurring
 		Context:           def.Context,
 		RecurringTaskId:   &id,
 	}
+}
+
+type zeroLogCronLogger struct {
+}
+
+func (z zeroLogCronLogger) Info(msg string, keysAndValues ...interface{}) {
+	if log.Info().Enabled() {
+		formatted := formatTimeValues(keysAndValues)
+		log.Info().Fields(formatted).Msg(msg)
+	}
+}
+
+func (z zeroLogCronLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	if log.Error().Enabled() {
+		formatted := formatTimeValues(keysAndValues)
+		log.Error().Err(err).Fields(formatted).Msg(msg)
+	}
+}
+
+// formatTimeValues formats any time.Time values as RFC3339 *and*
+// returns the even-odd idx key-value pair slice as a map
+func formatTimeValues(keysAndValues []interface{}) map[string]interface{} {
+	formattedArgs := make(map[string]interface{}, len(keysAndValues)/2)
+	for idx := 0; idx < len(keysAndValues); idx += 2 {
+		var key string
+		if s, ok := keysAndValues[idx].(string); ok {
+			key = s
+		} else {
+			key = fmt.Sprint(keysAndValues[idx])
+		}
+		valueIdx := idx + 1
+		if len(keysAndValues) > valueIdx {
+			value := keysAndValues[valueIdx]
+			if t, ok := value.(time.Time); ok {
+				value = t.Format(time.RFC3339)
+			}
+			formattedArgs[key] = value
+		}
+	}
+	return formattedArgs
 }

--- a/internal/infra/cron/task/recurring/scheduler_test.go
+++ b/internal/infra/cron/task/recurring/scheduler_test.go
@@ -1,6 +1,7 @@
 package recurring
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -223,4 +224,64 @@ var skipIfOutstandingTaskToSchedule = recurring.Task{
 	IsDeleted:                   false,
 	LoadedAt:                    nil,
 	Metadata:                    metadata.Metadata{},
+}
+
+func Test_zeroLogCronLogger_Info(t *testing.T) {
+	type args struct {
+		msg           string
+		keysAndValues []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "with message and key-values",
+			args: args{
+				msg: "hello",
+				keysAndValues: []interface{}{
+					"id", "my id",
+					"date", time.Now(),
+					1, "just one",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			z := zeroLogCronLogger{}
+			z.Info(tt.args.msg, tt.args.keysAndValues...)
+		})
+	}
+}
+
+func Test_zeroLogCronLogger_Error(t *testing.T) {
+	type args struct {
+		err           error
+		msg           string
+		keysAndValues []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "with message and key-values",
+			args: args{
+				msg: "hello",
+				err: fmt.Errorf("noooo"),
+				keysAndValues: []interface{}{
+					"id", "my id",
+					"date", time.Now(),
+					1, "just one",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			z := zeroLogCronLogger{}
+			z.Error(tt.args.err, tt.args.msg, tt.args.keysAndValues...)
+		})
+	}
 }

--- a/internal/infra/elasticsearch/integration_tests/task_service_test.go
+++ b/internal/infra/elasticsearch/integration_tests/task_service_test.go
@@ -29,6 +29,7 @@ func buildTasksService() task.Service {
 			Queues: config.Queues{
 				LastActivityTrackerMaxSize: 1000,
 				RefreshIfLastTouchedOver:   1 * time.Second,
+				RefreshIfLastTouchedUnder:  2 * time.Second,
 			},
 			Defaults: config.TasksDefaults{
 				BlockFor:                    3 * time.Second,


### PR DESCRIPTION
* Add another knob to make it possible to refresh indices more aggressively when
  looking for outstanding Tasks for a given Recurring Task
* For Recurring Tasks that have skip_if_outstanding_tasks_exist set to true,
  wrap with DelayIfStillRunning before passing to robconfig/cron; that way
  we can ensure that a latter scheduled enqueuing doesn't enqueue something at
  the same time as an earlier, already running scheduled enqueuing
* Update robconfig/cron integration so that we wrap with cron.Recover, passing
  in a logger
* Add readme section to mention Recurring Tasks and limitations
